### PR TITLE
@nuxt/fontawesome replaced by @vue/fontawesome

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,7 +9,6 @@
 <script>
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
-import "@fortawesome/fontawesome-svg-core/styles.css";
 
 export default {
   components: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,19 +9,19 @@
 <script>
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
+import "@fortawesome/fontawesome-svg-core/styles.css";
 
 export default {
   components: {
     NavBar,
-    Footer
-  }
+    Footer,
+  },
 };
 </script>
 
 <style>
 html {
-  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 16px;
   word-spacing: 1px;
   -ms-text-size-adjust: 100%;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,7 +33,6 @@ export default {
   css: [
     // SCSS file in the project
     "@/assets/scss/main.scss",
-    "@fortawesome/fontawesome-svg-core/styles.css",
   ],
   components: true,
   content: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,6 +33,7 @@ export default {
   css: [
     // SCSS file in the project
     "@/assets/scss/main.scss",
+    "@fortawesome/fontawesome-svg-core/styles.css",
   ],
   components: true,
   content: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,6 +33,7 @@ export default {
   css: [
     // SCSS file in the project
     "@/assets/scss/main.scss",
+    "@fortawesome/fontawesome-svg-core/styles.css",
   ],
   components: true,
   content: {
@@ -41,7 +42,7 @@ export default {
       remarkPlugins: ["remark-emoji"],
     },
   },
-  buildModules: ["@nuxtjs/dotenv", "@nuxtjs/fontawesome", "@nuxtjs/google-analytics"],
+  buildModules: ["@nuxtjs/dotenv", "@nuxtjs/google-analytics"],
   /*
    ** Nuxt.js modules
    */
@@ -56,16 +57,11 @@ export default {
     "@nuxtjs/cloudinary",
     "vue-social-sharing/nuxt",
   ],
+  plugins: ["~/plugins/fontawesome.js"],
   cloudinary: {
     cloudName: "marcelo-munhoz",
     apikey: process.env.CLODINARY_APIKEY,
     apiSecret: process.env.CLODINARY_APIKEYSECRET,
-  },
-  fontawesome: {
-    icons: {
-      solid: true,
-      brands: true,
-    },
   },
   googleAnalytics: {
     id: process.env.GOOGLE_USERID,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,8 +33,6 @@ export default {
   css: [
     // SCSS file in the project
     "@/assets/scss/main.scss",
-    "@fortawesome/free-solid-svg-icons",
-    "@fortawesome/free-brands-svg-icons",
   ],
   components: true,
   content: {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "nuxtjs-darkmode-js-module": "^1.0.3",
     "remark-emoji": "^2.2.0",
     "vue-social-sharing": "^3.0.7",
-    "vuejs-emojis": "^0.0.1"
-  },
-  "devDependencies": {
+    "vuejs-emojis": "^0.0.1",
     "@fortawesome/free-brands-svg-icons": "^5.15.3",
-    "@fortawesome/free-solid-svg-icons": "^5.11.2",
+    "@fortawesome/free-solid-svg-icons": "^5.11.2"
+  },
+  "devDependencies": {    
     "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/fontawesome": "^1.1.2",
     "@nuxtjs/google-analytics": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "email": "me@marcelomunhoz.com"
   },
   "dependencies": {
+    "@fortawesome/free-brands-svg-icons": "^5.15.3",
+    "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@nuxt/content": "^1.14.0",
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/cloudinary": "^1.0.3-beta-4",
+    "@nuxtjs/fontawesome": "^1.1.2",
     "bootstrap": "^5.0.1",
     "bootstrap-vue": "^2.0.0",
     "nuxt": "^2.0.0",
@@ -17,13 +20,10 @@
     "nuxtjs-darkmode-js-module": "^1.0.3",
     "remark-emoji": "^2.2.0",
     "vue-social-sharing": "^3.0.7",
-    "vuejs-emojis": "^0.0.1",
-    "@fortawesome/free-brands-svg-icons": "^5.15.3",
-    "@fortawesome/free-solid-svg-icons": "^5.11.2"
+    "vuejs-emojis": "^0.0.1"
   },
   "devDependencies": {    
     "@nuxtjs/dotenv": "^1.4.1",
-    "@nuxtjs/fontawesome": "^1.1.2",
     "@nuxtjs/google-analytics": "^2.4.0",
     "@vue/test-utils": "^1.0.0-beta.27",
     "babel-jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "email": "me@marcelomunhoz.com"
   },
   "dependencies": {
-    "@fortawesome/free-brands-svg-icons": "^5.15.3",
-    "@fortawesome/free-solid-svg-icons": "^5.11.2",
+    "@fortawesome/fontawesome-svg-core": "^6.1.2",
+    "@fortawesome/free-brands-svg-icons": "^6.1.2",
+    "@fortawesome/free-solid-svg-icons": "^6.1.2",
+    "@fortawesome/vue-fontawesome": "^2.0.8",
     "@nuxt/content": "^1.14.0",
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/cloudinary": "^1.0.3-beta-4",
-    "@nuxtjs/fontawesome": "^1.1.2",
     "bootstrap": "^5.0.1",
     "bootstrap-vue": "^2.0.0",
     "nuxt": "^2.0.0",
@@ -22,7 +23,7 @@
     "vue-social-sharing": "^3.0.7",
     "vuejs-emojis": "^0.0.1"
   },
-  "devDependencies": {    
+  "devDependencies": {
     "@nuxtjs/dotenv": "^1.4.1",
     "@nuxtjs/google-analytics": "^2.4.0",
     "@vue/test-utils": "^1.0.0-beta.27",

--- a/plugins/fontawesome.js
+++ b/plugins/fontawesome.js
@@ -1,0 +1,11 @@
+import Vue from "vue";
+import { library, config } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { fab } from "@fortawesome/free-brands-svg-icons";
+import { fas } from "@fortawesome/free-solid-svg-icons";
+
+config.autoAddCss = false;
+
+library.add(fab, fas);
+
+Vue.component("font-awesome-icon", FontAwesomeIcon);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8094,7 +8094,7 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse-path@5.0.0, parse-path@^4.0.0:
+parse-path@^4.0.0, parse-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-5.0.0.tgz#f933152f3c6d34f4cf36cfc3d07b138ac113649d"
   integrity sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,41 +978,36 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@fortawesome/fontawesome-common-types@^0.2.36":
-  version "0.2.36"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
-  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+"@fortawesome/fontawesome-common-types@6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz#c1095b1bbabf19f37f9ff0719db38d92a410bcfe"
+  integrity sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==
 
-"@fortawesome/fontawesome-common-types@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
-  integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==
-
-"@fortawesome/fontawesome-svg-core@^1.2.27":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz#343fac91fa87daa630d26420bfedfba560f85885"
-  integrity sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==
+"@fortawesome/fontawesome-svg-core@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz#11e2e8583a7dea75d734e4d0e53d91c63fae7511"
+  integrity sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.3.0"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
-"@fortawesome/free-brands-svg-icons@^5.15.3":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz#ec8a44dd383bcdd58aa7d1c96f38251e6fec9733"
-  integrity sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==
+"@fortawesome/free-brands-svg-icons@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.2.tgz#14160348b8ad5986b3805797dc4377a96e0014d9"
+  integrity sha512-b2eMfXQBsSxh52pcPtYchURQs6BWNh3zVTG8XH8Lv6V4kDhEg7D0kHN+K1SZniDiPb/e5tBlaygsinMUvetITA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
-"@fortawesome/free-solid-svg-icons@^5.11.2":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
-  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+"@fortawesome/free-solid-svg-icons@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.2.tgz#491d668b8a6603698d0ce1ac620f66fd22b74c84"
+  integrity sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "6.1.2"
 
-"@fortawesome/vue-fontawesome@^0.1.9":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34"
-  integrity sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==
+"@fortawesome/vue-fontawesome@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.8.tgz#9c9ae1cd2cbe7f4b0c63dd53709c26167d541aa6"
+  integrity sha512-SRmP0q9Ox4zq8ydDR/hrH+23TVU1bdwYVnugLVaAIwklOHbf56gx6JUGlwES7zjuNYqzKgl8e39iYf6ph8qSQw==
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -1715,14 +1710,6 @@
   dependencies:
     consola "^2.10.1"
     dotenv "^8.1.0"
-
-"@nuxtjs/fontawesome@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/fontawesome/-/fontawesome-1.1.2.tgz#0add6519095b392bdffb6e3ad40f3026d20f5c44"
-  integrity sha512-QAfo7hdc6hiCOohdR861oNQ+riKW/kD22bYyvaC++xXiiC1hBQcrRQ6xXd5gln+6SKCwT09+C4kGjzTgrwtr7w==
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.27"
-    "@fortawesome/vue-fontawesome" "^0.1.9"
 
 "@nuxtjs/google-analytics@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
[\@nuxt-fontawesome](https://yarnpkg.com/package/nuxt-fontawesome) loses css style on prod mode.

It was replaced by [\@fortawesome/vue-fontawesome](https://yarnpkg.com/package/@fortawesome/vue-fontawesome)