### PR TITLE
Fix: add staging origin to CORS policy

### DIFF
--- a/app/middleware/server.js
+++ b/app/middleware/server.js
@@ -1,17 +1,25 @@
 import express from "express";
-import path from "path";
 import dotenv from "dotenv";
 import cors from "cors";
-import { fileURLToPath } from "url";
 import contentfulRoutes from "./routes/contentful.js";
 
 dotenv.config();
 
 const app = express();
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = process.env.PORT || 3000;
+const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",") || [];
 
-app.use(cors());
+app.use(
+  cors({
+    origin: function (origin, callback) {
+      // Allow Postman or Allowed list
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      callback(new Error("Not allowed by CORS"));
+    },
+  })
+);
 
 // Keeps banckend alive
 app.get("/healthz", (_, res) => {


### PR DESCRIPTION
This PR updates the server's CORS configuration to include the Netlify staging domain as an allowed origin. This resolves 500 errors caused by CORS restrictions when previewing the app from Netlify deploy previews.

- Added multiple allowed origins support
- Updated server to dynamically allow origin based on environment